### PR TITLE
feat: Reloj vagrant up

### DIFF
--- a/VM/vagrantup_clock.sh
+++ b/VM/vagrantup_clock.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+vagrant up | awk '{ print strftime("[%Y-%m-%d %H:%M:%S]"), $0; fflush(); }'
+


### PR DESCRIPTION
feat: Reloj en la ejecucion de cada comando para cronometrar el arranque de la VM (ejecutar .vagrantup_clock.sh en vez de vagrant up para cronometrar el arranque)